### PR TITLE
Disable Bad Charset error for Android text linter

### DIFF
--- a/libcassowary/src/lint/engine/MobileLintEngine.php
+++ b/libcassowary/src/lint/engine/MobileLintEngine.php
@@ -146,6 +146,8 @@ final class MobileLintEngine extends ArcanistLintEngine {
         $linters[] = id(new ArcanistTextLinter())->setPaths($android_paths)
                 ->setCustomSeverityMap(
                     array(
+                        ArcanistTextLinter::LINT_BAD_CHARSET =>
+                        ArcanistLintSeverity::SEVERITY_DISABLED,
                         ArcanistTextLinter::LINT_LINE_WRAP =>
                         ArcanistLintSeverity::SEVERITY_ADVICE,
                     ))->setMaxLineLength($lintsetting_maxlinelength);


### PR DESCRIPTION
Test Plan:
- Patch this change to your `/opt/cassowary` repository, then make a code change in an Android project repository and add a bunch of French characters.
- Run `arc diff` and verify that your diff isn't riddled with `Error (TXT5) Bad Charset`.

Reviewers: sagrawal, arodriguez, rsuri, vramos, vvelma, rjoseph, pikede, jgreene, mpellegrino, jvincent, lvelazquez, rpublicover, GCruz, rreddy, skarunanidhi

JIRA Issues: VIT-450, VIT-474

Differential Revision: https://phab.imobile3.local/D17763