### PR TITLE
Minor prep work for development with NetBeans IDE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,9 @@ libcassowary/src/.phutil_module_cache
 libcassowary/support/lint/android/bin/*
 libcassowary/support/lint/android/.classpath
 libcassowary/support/lint/android/.project
+
+# Mac Files
+.DS_Store
+
+# Apache NetBeans IDE
+nbproject/

--- a/README.md
+++ b/README.md
@@ -147,6 +147,20 @@ The .NET linter invokes the full ReSharper suite and can utilize any local confi
 .NET unit testing supports both classic .NET and .NET Core.
 
 ___
+Development and Maintenance
+--------------------------------
+
+## Apache NetBeans IDE 11.3 Setup
+NetBeans Download: https://netbeans.apache.org/download/index.html  
+
+Set `Run Configuration` to `Run As: Script (run in command line)`  
+
+* For Linux / Unix: Set `PHP Interpreter` to `/usr/bin/php`  
+* For Windows: Set the interpreter to your `php.exe` file  
+
+You can specify PHP Version 7.4 and use Default Encoding UTF-8.  
+
+___
 License / Support
 =================
 


### PR DESCRIPTION
Summary:
- Add `nbproject/` dir to the `.gitignore` for compatibility with the Apache NetBeans IDE.
- Add `.DS_Store` file to the `.gitignore` cuz nobody likes that file.
- Add brief notes about `cassowary` project setup to the `README` for the NetBeans IDE, so you can use the script-driven PHP interpreter.

Test Plan:
- Download NetBeans IDE and configure the `cassowary` project using the `README` as a guide.
- Verify you can successfully navigate the `cassowary` codebase.
- Celebrate success \o/

Reviewers: jrawlinson, skarunanidhi, sagrawal, arodriguez, rsuri, vramos, vvelma, rjoseph, pikede, jgreene, mpellegrino, jvincent, lvelazquez, rpublicover, GCruz, rreddy

JIRA Issues: VIT-474

Differential Revision: https://phab.imobile3.local/D18039