### PR TITLE
Disable Bad Charset error for iOS text linter

### DIFF
--- a/libcassowary/src/lint/engine/MobileLintEngine.php
+++ b/libcassowary/src/lint/engine/MobileLintEngine.php
@@ -73,6 +73,8 @@ final class MobileLintEngine extends ArcanistLintEngine {
         $linters[] = id(new ArcanistTextLinter())->setPaths($ios_text_paths)
                 ->setCustomSeverityMap(
                     array(
+                        ArcanistTextLinter::LINT_BAD_CHARSET =>
+                        ArcanistLintSeverity::SEVERITY_DISABLED,
                         ArcanistTextLinter::LINT_LINE_WRAP =>
                         ArcanistLintSeverity::SEVERITY_ADVICE,
                     ))->setMaxLineLength($lintsetting_maxlinelength);


### PR DESCRIPTION
Summary: Disable Bad Charset error for iOS text linter

Test Plan: See if lint still complains at copyright symbol

Reviewers: tlahtinen, kschanz, gpadamata, jrodden, rpatel, msosa, mgupta, skarunanidhi

Reviewed By: tlahtinen

Subscribers: kschanz

Differential Revision: https://phab.imobile3.local/D19483